### PR TITLE
hotfix: login base uri 변경

### DIFF
--- a/src/main/java/com/example/spinlog/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/spinlog/global/security/SecurityConfig.java
@@ -49,6 +49,9 @@ public class SecurityConfig {
                         .disable()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(url -> url
+                                .baseUri("/api/users/login")
+                        )
                         .clientRegistrationRepository(customClientRegistrationRepository.clientRegistrationRepository())
                         .authorizedClientService(customOAuth2AuthorizedClientService.oAuth2AuthorizedClientService(
                                 jdbcTemplate, customClientRegistrationRepository.clientRegistrationRepository()


### PR DESCRIPTION
#### 소셜 로그인 기본 화면을 요청하는 uri를 api 스펙에 알맞게 수정
- `/oauth2/authorization/{providerId}` -> `/api/users/login/{providerId}`