### PR TITLE
Refactor/statistics period dependency

### DIFF
--- a/src/main/java/com/example/spinlog/global/config/TimeConfig.java
+++ b/src/main/java/com/example/spinlog/global/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.example.spinlog.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledService.java
@@ -1,6 +1,7 @@
 package com.example.spinlog.statistics.scheduled;
 
 import com.example.spinlog.article.entity.RegisterType;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.caching.GenderStatisticsCacheWriteService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsCacheFetchService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.Map;
 
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
 import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
 import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 
@@ -22,22 +24,24 @@ public class GenderStatisticsCacheVerifyScheduledService {
     private final GenderStatisticsCacheFetchService genderStatisticsCacheFetchService;
     private final GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService;
     private final GenderStatisticsCacheWriteService genderStatisticsCacheWriteService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
 
     @Scheduled(cron = "0 0 5 * * *")
     public void updateGenderStatisticsCacheIfCacheMiss() {
-        updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND);
-        updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SAVE);
+        Period period = statisticsPeriodManager.getStatisticsPeriod();
+        updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND, period);
+        updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SAVE, period);
 
-        updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND);
-        updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SAVE);
+        updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND, period);
+        updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SAVE, period);
 
-        updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND);
-        updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SAVE);
+        updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND, period);
+        updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SAVE, period);
     }
 
-    public void updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType registerType) {
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+    public void updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType registerType, Period period) {
+        LocalDate endDate = period.endDate();
+        LocalDate startDate = period.startDate();
         CountsAndSums cacheData = genderStatisticsCacheFetchService
                 .getAmountAveragesEachGenderAndEmotion(registerType);
         CountsAndSums repositoryData = genderStatisticsRepositoryFetchService
@@ -53,9 +57,9 @@ public class GenderStatisticsCacheVerifyScheduledService {
                     + ") GenderEmotionAmountAverage Cache Data and Repository Data are same.");
     }
 
-    public void updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType registerType) {
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+    public void updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType registerType, Period period) {
+        LocalDate endDate = period.endDate();
+        LocalDate startDate = period.startDate();
         Map<String, Object> cacheData = genderStatisticsCacheFetchService
                 .getAmountSumsEachGenderAndDay(registerType);
         Map<String, Object> repositoryData = genderStatisticsRepositoryFetchService
@@ -72,9 +76,9 @@ public class GenderStatisticsCacheVerifyScheduledService {
     }
 
 
-    public void updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType registerType) {
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+    public void updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType registerType, Period period) {
+        LocalDate endDate = period.endDate();
+        LocalDate startDate = period.startDate();
         CountsAndSums cacheData = genderStatisticsCacheFetchService
                 .getSatisfactionAveragesEachGender(registerType);
         CountsAndSums repositoryData = genderStatisticsRepositoryFetchService

--- a/src/main/java/com/example/spinlog/statistics/service/StatisticsPeriodManager.java
+++ b/src/main/java/com/example/spinlog/statistics/service/StatisticsPeriodManager.java
@@ -1,0 +1,40 @@
+package com.example.spinlog.statistics.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+@Slf4j
+public class StatisticsPeriodManager {
+    private static final int PERIOD_CRITERIA = 30;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private final Clock clock;
+
+    public StatisticsPeriodManager(Clock clock) {
+        this.clock = clock;
+        LocalDate endDate = LocalDate.now(clock);
+        this.startDate = endDate.minusDays(PERIOD_CRITERIA);
+        this.endDate = endDate;
+
+        // todo 0시 ~ 4시 안맞음 - 일단은 이 시간을 제외한 시간대에 실행되도록 설정
+    }
+
+    public Period getStatisticsPeriod() {
+        return new Period(startDate, endDate);
+    }
+
+    // todo GenderStatsticsCacheScheduledService에서만 사용하도록 변경
+    public void updateStatisticsPeriod() {
+        LocalDate endDate = LocalDate.now(clock);
+        this.startDate = endDate.minusDays(PERIOD_CRITERIA);
+        this.endDate = endDate;
+    }
+
+    public record Period(LocalDate startDate, LocalDate endDate) { }
+}

--- a/src/main/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheFallbackService.java
+++ b/src/main/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheFallbackService.java
@@ -5,6 +5,7 @@ import com.example.spinlog.statistics.exception.InvalidCacheException;
 import com.example.spinlog.statistics.repository.dto.GenderDailyAmountSumDto;
 import com.example.spinlog.statistics.repository.dto.GenderEmotionAmountAverageDto;
 import com.example.spinlog.statistics.repository.dto.GenderSatisfactionAverageDto;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsCacheFetchService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
 import com.example.spinlog.utils.StatisticsCacheUtils;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
 import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
 import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 
@@ -26,6 +28,7 @@ public class GenderStatisticsCacheFallbackService {
     private final GenderStatisticsCacheFetchService genderStatisticsCacheFetchService;
     private final GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService;
     private final GenderStatisticsCacheWriteService genderStatisticsCacheWriteService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
 
     public List<GenderEmotionAmountAverageDto> getAmountAveragesEachGenderAndEmotion(RegisterType registerType){
         try {
@@ -34,8 +37,9 @@ public class GenderStatisticsCacheFallbackService {
         } catch(InvalidCacheException e) {
             log.warn("GenderEmotionAmountAverage Cache fallback occurred. Query Database and Cache will be updated.", e);
 
-            LocalDate endDate = LocalDate.now();
-            LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+            LocalDate endDate = period.endDate();
+            LocalDate startDate = period.startDate();
             CountsAndSums genderEmotionAmountCountsAndSums = genderStatisticsRepositoryFetchService
                     .getGenderEmotionAmountCountsAndSums(registerType, startDate, endDate);
 
@@ -53,8 +57,9 @@ public class GenderStatisticsCacheFallbackService {
         } catch(InvalidCacheException e) {
             log.warn("GenderDailyAmountSum Cache fallback occurred. Query Database and Cache will be updated.", e);
 
-            LocalDate endDate = LocalDate.now();
-            LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+            LocalDate endDate = period.endDate();
+            LocalDate startDate = period.startDate();
             Map<String, Object> genderDailyAmountSums = genderStatisticsRepositoryFetchService
                     .getGenderDateAmountSums(registerType, startDate, endDate);
 
@@ -71,8 +76,9 @@ public class GenderStatisticsCacheFallbackService {
         } catch(InvalidCacheException e) {
             log.warn("GenderSatisfactionAverage Cache fallback occurred. Query Database and Cache will be updated.", e);
 
-            LocalDate endDate = LocalDate.now();
-            LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+            LocalDate endDate = period.endDate();
+            LocalDate startDate = period.startDate();
             CountsAndSums genderSatisfactionCountsAndSums = genderStatisticsRepositoryFetchService
                     .getGenderSatisfactionCountsAndSums(registerType, startDate, endDate);
 

--- a/src/main/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheSynchronizer.java
+++ b/src/main/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheSynchronizer.java
@@ -6,6 +6,7 @@ import com.example.spinlog.article.event.ArticleCreatedEvent;
 import com.example.spinlog.article.event.ArticleDeletedEvent;
 import com.example.spinlog.article.event.ArticleUpdatedEvent;
 import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.user.entity.Gender;
 import com.example.spinlog.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +16,15 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDateTime;
 
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
 import static com.example.spinlog.utils.CacheKeyNameUtils.*;
-import static com.example.spinlog.utils.StatisticsCacheUtils.PERIOD_CRITERIA;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GenderStatisticsCacheSynchronizer {
     private final HashCacheService hashCacheService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
 
     @TransactionalEventListener
     public void updateStatisticsCacheFromNewData(ArticleCreatedEvent event) {
@@ -59,9 +61,9 @@ public class GenderStatisticsCacheSynchronizer {
     }
 
     private boolean isNotInStatisticsPeriodCriteria(LocalDateTime spendDate) {
-        // todo 새벽 시간 캐시 데이터 정합성 해결 위해 별도의 클래스로 분리
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(PERIOD_CRITERIA);
+        Period period = statisticsPeriodManager.getStatisticsPeriod();
+        LocalDateTime endDate = period.endDate().atStartOfDay();
+        LocalDateTime startDate = period.startDate().atStartOfDay();
         return !(spendDate.isAfter(startDate) && spendDate.isBefore(endDate));
     }
 

--- a/src/main/java/com/example/spinlog/statistics/service/caching/StatisticsCacheSynchronizerAfterUserWrite.java
+++ b/src/main/java/com/example/spinlog/statistics/service/caching/StatisticsCacheSynchronizerAfterUserWrite.java
@@ -1,7 +1,7 @@
 package com.example.spinlog.statistics.service.caching;
 
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
-import com.example.spinlog.user.entity.Gender;
 import com.example.spinlog.user.entity.User;
 import com.example.spinlog.user.event.UserUpdatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDate;
 
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
 import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
 import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 
@@ -20,18 +21,18 @@ import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 public class StatisticsCacheSynchronizerAfterUserWrite {
     private final GenderStatisticsCacheWriteService genderStatisticsCacheWriteService;
     private final GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
 
 
     @TransactionalEventListener
     public void updateStatisticsCacheFromUpdatedUser(UserUpdatedEvent event) {
         User originalUser = event.getOriginalUser();
         User updatedUser = event.getUpdatedUser();
-        Gender originalGender = originalUser.getGender();
-        Gender updatedGender = updatedUser.getGender();
 
         if(isGenderChanged(originalUser, updatedUser)) {
-            LocalDate endDate = LocalDate.now();
-            LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+            LocalDate endDate = period.endDate();
+            LocalDate startDate = period.startDate();
             AllStatisticsResult repositoryResult = genderStatisticsRepositoryFetchService
                     .getGenderStatisticsAllDataByUserId(updatedUser.getId(), startDate, endDate);
 

--- a/src/main/java/com/example/spinlog/utils/StatisticsCacheUtils.java
+++ b/src/main/java/com/example/spinlog/utils/StatisticsCacheUtils.java
@@ -22,6 +22,7 @@ import static com.example.spinlog.user.entity.Gender.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StatisticsCacheUtils {
+    // todo mbti 캐싱 작업 후 삭제
     public static final int PERIOD_CRITERIA = 30;
 
     public static Map<String, Object> toGenderEmotionMap(List<GenderEmotionAmountAverageDto> dtos){

--- a/src/main/java/com/example/spinlog/utils/StatisticsCacheUtils.java
+++ b/src/main/java/com/example/spinlog/utils/StatisticsCacheUtils.java
@@ -45,6 +45,7 @@ public class StatisticsCacheUtils {
                         GenderDataDto::getValue));
     }
 
+    // todo Map to Map reverse, not list
     public static Map<String, Object> toReverseGenderEmotionMap(List<GenderEmotionAmountAverageDto> dtos){
         return dtos.stream()
                 .collect(Collectors.toMap(

--- a/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledServiceTest.java
@@ -145,8 +145,6 @@ class GenderStatisticsCacheRefreshScheduledServiceTest {
                 .isNull();
     }
 
-    // todo GenderDailyAmountSum 31일 전 key 삭제 & 1일 전 key 추가 테스트
-
     private void verifyRequestAllStatisticsDataFromRepository(LocalDate startDate, LocalDate endDate) {
         // any() -> SPEND, SAVE
         verify(genderStatisticsRepository, times(2)).getAmountSumsEachGenderAndEmotionBetweenStartDateAndEndDate(

--- a/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledServiceTest.java
@@ -4,6 +4,7 @@ import com.example.spinlog.article.entity.Emotion;
 import com.example.spinlog.statistics.repository.GenderStatisticsRepository;
 import com.example.spinlog.statistics.repository.dto.GenderDailyAmountSumDto;
 import com.example.spinlog.statistics.repository.dto.GenderEmotionAmountAverageDto;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
 import com.example.spinlog.user.entity.Gender;
 import com.example.spinlog.util.CacheConfiguration;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -31,9 +33,13 @@ class GenderStatisticsCacheRefreshScheduledServiceTest {
     GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService =
             new GenderStatisticsRepositoryFetchService(genderStatisticsRepository);
     MockHashCacheService cacheService = new MockHashCacheService();
+    StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
 
     GenderStatisticsCacheRefreshScheduledService targetService =
-            new GenderStatisticsCacheRefreshScheduledService(cacheService, genderStatisticsRepositoryFetchService);
+            new GenderStatisticsCacheRefreshScheduledService(
+                    cacheService,
+                    genderStatisticsRepositoryFetchService,
+                    statisticsPeriodManager);
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.spinlog.statistics.scheduled;
 
 import com.example.spinlog.article.entity.RegisterType;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.caching.GenderStatisticsCacheWriteService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsCacheFetchService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
@@ -11,8 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Clock;
 import java.util.Map;
 
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
 import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -24,10 +27,13 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
     GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService = mock(GenderStatisticsRepositoryFetchService.class);
     GenderStatisticsCacheWriteService genderStatisticsCacheWriteService = mock(GenderStatisticsCacheWriteService.class);
 
+    StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
+
     GenderStatisticsCacheVerifyScheduledService targetService = new GenderStatisticsCacheVerifyScheduledService(
             genderStatisticsCacheFetchService,
             genderStatisticsRepositoryFetchService,
-            genderStatisticsCacheWriteService);
+            genderStatisticsCacheWriteService,
+            statisticsPeriodManager);
 
     @Nested
     class updateGenderEmotionAmountAverageCacheIfCacheMiss {
@@ -43,8 +49,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                             Map.of("key1", 1, "key2", 2),
                             Map.of("key1", 1, "key2", 2)));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService, never()).putAmountCountsAndSumsByGenderAndEmotion(any(), any());
@@ -62,8 +70,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                             Map.of("key1", 1, "key2", 2),
                             Map.of("key1", 1, "key2", 100)));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService).putAmountCountsAndSumsByGenderAndEmotion(any(), any());
@@ -82,8 +92,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                     .thenReturn(
                             Map.of("key1", 1, "key2", 2));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService, never()).putAmountSumsByGenderAndDate(any(), any());
@@ -99,8 +111,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                     .thenReturn(
                             Map.of("key1", 1, "key2", 100));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService).putAmountSumsByGenderAndDate(any(), any());
@@ -121,8 +135,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                             Map.of("key1", 1.0, "key2", 2.0),
                             Map.of("key1", 1, "key2", 2)));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService, never()).putSatisfactionCountsAndSumsByGender(any(), any());
@@ -140,8 +156,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                             Map.of("key1", 1.0, "key2", 2.0),
                             Map.of("key1", 1, "key2", 100)));
 
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
             // when
-            targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND);
+            targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
             verify(genderStatisticsCacheWriteService).putSatisfactionCountsAndSumsByGender(any(), any());

--- a/src/test/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheFallbackServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheFallbackServiceTest.java
@@ -6,6 +6,7 @@ import com.example.spinlog.statistics.exception.InvalidCacheException;
 import com.example.spinlog.statistics.repository.dto.GenderDailyAmountSumDto;
 import com.example.spinlog.statistics.repository.dto.GenderEmotionAmountAverageDto;
 import com.example.spinlog.statistics.repository.dto.GenderSatisfactionAverageDto;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsCacheFetchService;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
 import com.example.spinlog.user.entity.Gender;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 
@@ -34,11 +36,14 @@ class GenderStatisticsCacheFallbackServiceTest {
     GenderStatisticsCacheWriteService genderStatisticsCacheWriteService =
              mock(GenderStatisticsCacheWriteService.class);
 
+    StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
+
     GenderStatisticsCacheFallbackService targetService =
             new GenderStatisticsCacheFallbackService(
                     genderStatisticsCacheFetchService,
                     genderStatisticsRepositoryFetchService,
-                    genderStatisticsCacheWriteService);
+                    genderStatisticsCacheWriteService,
+                    statisticsPeriodManager);
     @Nested
     class getAmountAveragesEachGenderAndEmotion {
         @Test

--- a/src/test/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheSynchronizerTest.java
+++ b/src/test/java/com/example/spinlog/statistics/service/caching/GenderStatisticsCacheSynchronizerTest.java
@@ -6,6 +6,7 @@ import com.example.spinlog.article.entity.RegisterType;
 import com.example.spinlog.article.event.ArticleCreatedEvent;
 import com.example.spinlog.article.event.ArticleDeletedEvent;
 import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.user.entity.Gender;
 import com.example.spinlog.user.entity.User;
 import com.example.spinlog.util.ArticleFactory;
@@ -13,6 +14,7 @@ import com.example.spinlog.util.MockHashCacheService;
 import org.junit.jupiter.api.*;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.example.spinlog.utils.CacheKeyNameUtils.*;
@@ -24,8 +26,11 @@ import static org.mockito.Mockito.*;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GenderStatisticsCacheSynchronizerTest {
     HashCacheService hashCacheService = spy(MockHashCacheService.class);
+    StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
     GenderStatisticsCacheSynchronizer targetService =
-            new GenderStatisticsCacheSynchronizer(hashCacheService);
+            new GenderStatisticsCacheSynchronizer(
+                    hashCacheService,
+                    statisticsPeriodManager);
 
     RegisterType registerType = RegisterType.SPEND;
     User user = User.builder()
@@ -34,7 +39,7 @@ class GenderStatisticsCacheSynchronizerTest {
             .email("email@email")
             .build();
     Article article = ArticleFactory.builder()
-            .spendDate(LocalDateTime.now())
+            .spendDate(LocalDateTime.now().minusDays(1))
             .emotion(Emotion.PROUD)
             .amount(5)
             .satisfaction(5.0f)

--- a/src/test/java/com/example/spinlog/util/ArticleFactory.java
+++ b/src/test/java/com/example/spinlog/util/ArticleFactory.java
@@ -3,6 +3,7 @@ package com.example.spinlog.util;
 import com.example.spinlog.article.entity.Article;
 import com.example.spinlog.article.entity.Emotion;
 import com.example.spinlog.article.entity.RegisterType;
+import com.example.spinlog.article.service.request.ArticleCreateRequest;
 import com.example.spinlog.user.entity.User;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
@@ -69,6 +70,22 @@ public class ArticleFactory {
                 .aiComment(aiComment)
                 .amount(amount)
                 .registerType(registerType)
+                .build();
+    }
+
+    public ArticleCreateRequest toCreateRequest() {
+
+        return ArticleCreateRequest.builder()
+                .content(content)
+                .spendDate(spendDate.toString())
+                .event(event)
+                .thought(thought)
+                .emotion(emotion.name())
+                .satisfaction(satisfaction)
+                .reason(reason)
+                .improvements(improvements)
+                .amount(amount)
+                .registerType(registerType.name())
                 .build();
     }
 }

--- a/src/test/java/com/example/spinlog/util/MockHashCacheService.java
+++ b/src/test/java/com/example/spinlog/util/MockHashCacheService.java
@@ -1,6 +1,7 @@
 package com.example.spinlog.util;
 
 import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.exception.InvalidCacheException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,8 +17,13 @@ public class MockHashCacheService implements HashCacheService {
     @Override
     public void incrementDataInHash(String key, String hashKey, long delta) {
         Object dataFromHash = getDataFromHash(key, hashKey);
+        if(dataFromHash == null) {
+            putDataInHash(key, hashKey, delta);
+            return;
+        }
+
         if(!(dataFromHash instanceof Long)) {
-            throw new IllegalArgumentException("Data is not Double type");
+            throw new InvalidCacheException("Data is not Long type");
         }
 
         Long value = (Long) dataFromHash;
@@ -27,8 +33,9 @@ public class MockHashCacheService implements HashCacheService {
     @Override
     public void decrementDataInHash(String key, String hashKey, long delta) {
         Object dataFromHash = getDataFromHash(key, hashKey);
+
         if(!(dataFromHash instanceof Long)) {
-            throw new IllegalArgumentException("Data is not Double type");
+            throw new InvalidCacheException("Data is not Long type");
         }
 
         Long value = (Long) dataFromHash;
@@ -38,8 +45,13 @@ public class MockHashCacheService implements HashCacheService {
     @Override
     public void incrementDataInHash(String key, String hashKey, double delta) {
         Object dataFromHash = getDataFromHash(key, hashKey);
+        if(dataFromHash == null) {
+            putDataInHash(key, hashKey, delta);
+            return;
+        }
+
         if(!(dataFromHash instanceof Double)) {
-            throw new IllegalArgumentException("Data is not Double type");
+            throw new InvalidCacheException("Data is not Double type");
         }
 
         Double value = (Double) dataFromHash;
@@ -50,7 +62,7 @@ public class MockHashCacheService implements HashCacheService {
     public void decrementDataInHash(String key, String hashKey, double delta) {
         Object dataFromHash = getDataFromHash(key, hashKey);
         if(!(dataFromHash instanceof Double)) {
-            throw new IllegalArgumentException("Data is not Double type");
+            throw new InvalidCacheException("Data is not Double type");
         }
 
         Double value = (Double) dataFromHash;


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요? 🔍
모든 통계 관련 클래스들이 통계 기간의 시작일과 종료일을 얻는 로직을
한 클래스로부터 얻도록 수정한다.


## 어떻게 해결했나요? ✏️
통계 관련 클래스들이 통계 기간의 시작일과 종료일을 얻을 때
`LocalDate.now()` 처럼 각자 static method를 사용하지 않고
`StatisticsPeriodManager`라는 클래스로부터 통계 기간 변수를 얻게 만든다.

통계 기간 변수를 얻는 모든 클래스는 `StatisticsPeriodManager` 클래스에 대한 dependency가 추가된다.
그리고 위 클래스로부터 통계 기간의 시작일과 종료일을 얻어서 각자의 로직을 수행한다.

## 이슈 번호 ✅



## 추가 설명 (Optional) 📖

