### PR TITLE
Refactor/gender statistics cache

### DIFF
--- a/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheRefreshScheduledService.java
@@ -105,16 +105,18 @@ public class GenderStatisticsCacheRefreshScheduledService {
             hashCacheService.decrementDataInHash(getGenderEmotionStatisticsAmountCountKeyName(SAVE), k, (long)v);
         });
 
+        log.info("try to delete GenderAmountSum::SPEND:  {}", expiringStatisticsData.genderDailyAmountSpendSums());
+        log.info("try to delete GenderAmountSum::SAVE    {}", expiringStatisticsData.genderDailyAmountSaveSums());
         expiringStatisticsData.genderDailyAmountSpendSums().forEach((k, v) -> {
-            long data = (long) hashCacheService.getDataFromHash(getGenderDailyStatisticsAmountSumKeyName(SPEND), k);
-            if(data != (long)v)
-                log.warn("Data is not same. key: {}, repository: {}, cache: {}", k, data, v);
+            Object dataFromCache = hashCacheService.getDataFromHash(getGenderDailyStatisticsAmountSumKeyName(SPEND), k);
+            if(!v.equals(dataFromCache))
+                log.warn("Data is not same. key: {}, repository: {}, cache: {}", k, dataFromCache, v);
             hashCacheService.deleteHashKey(getGenderDailyStatisticsAmountSumKeyName(SPEND), k);
         });
         expiringStatisticsData.genderDailyAmountSaveSums().forEach((k, v) -> {
-            long data = (long) hashCacheService.getDataFromHash(getGenderDailyStatisticsAmountSumKeyName(SAVE), k);
-            if(data != (long)v)
-                log.warn("Data is not same. key: {}, repository: {}, cache: {}", k, data, v);
+            Object dataFromCache = hashCacheService.getDataFromHash(getGenderDailyStatisticsAmountSumKeyName(SAVE), k);
+            if(!v.equals(dataFromCache))
+                log.warn("Data is not same. key: {}, repository: {}, cache: {}", k, dataFromCache, v);
             hashCacheService.deleteHashKey(getGenderDailyStatisticsAmountSumKeyName(SAVE), k);
         });
 

--- a/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledService.java
@@ -42,11 +42,21 @@ public class GenderStatisticsCacheVerifyScheduledService {
     public void updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType registerType, Period period) {
         LocalDate endDate = period.endDate();
         LocalDate startDate = period.startDate();
-        CountsAndSums cacheData = genderStatisticsCacheFetchService
-                .getAmountAveragesEachGenderAndEmotion(registerType);
+        CountsAndSums cacheData;
+        try{
+            cacheData = genderStatisticsCacheFetchService
+                    .getAmountAveragesEachGenderAndEmotion(registerType);
+        } catch (Exception e) {
+            log.warn("RegisterType(" + registerType
+                    + ") Error occurred while fetching cache data. Cache will be updated.", e);
+            CountsAndSums repositoryData = genderStatisticsRepositoryFetchService
+                    .getGenderEmotionAmountCountsAndSums(registerType, startDate, endDate);
+            genderStatisticsCacheWriteService.putAmountCountsAndSumsByGenderAndEmotion(repositoryData, registerType);
+            return;
+        }
+
         CountsAndSums repositoryData = genderStatisticsRepositoryFetchService
                 .getGenderEmotionAmountCountsAndSums(registerType, startDate, endDate);
-
         if (isNotSame(cacheData, repositoryData)) {
             log.warn("RegisterType(" + registerType
                     + ") GenderEmotionAmountAverage Cache Data and Repository Data are not same. Cache will be updated.");
@@ -60,11 +70,21 @@ public class GenderStatisticsCacheVerifyScheduledService {
     public void updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType registerType, Period period) {
         LocalDate endDate = period.endDate();
         LocalDate startDate = period.startDate();
-        Map<String, Object> cacheData = genderStatisticsCacheFetchService
-                .getAmountSumsEachGenderAndDay(registerType);
+        Map<String, Object> cacheData;
+        try {
+            cacheData = genderStatisticsCacheFetchService
+                    .getAmountSumsEachGenderAndDay(registerType);
+        } catch (Exception e) {
+            log.warn("RegisterType(" + registerType
+                    + ") Error occurred while fetching cache data. Cache will be updated.", e);
+            Map<String, Object> repositoryData = genderStatisticsRepositoryFetchService
+                    .getGenderDateAmountSums(registerType, startDate, endDate);
+            genderStatisticsCacheWriteService.putAmountSumsByGenderAndDate(repositoryData, registerType);
+            return;
+        }
+
         Map<String, Object> repositoryData = genderStatisticsRepositoryFetchService
                 .getGenderDateAmountSums(registerType, startDate, endDate);
-
         if (isNotSame(cacheData, repositoryData)) {
             log.warn("RegisterType(" + registerType
                     + ") GenderDailyAmountSum Cache Data and Repository Data are not same. Cache will be updated.");
@@ -79,11 +99,21 @@ public class GenderStatisticsCacheVerifyScheduledService {
     public void updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType registerType, Period period) {
         LocalDate endDate = period.endDate();
         LocalDate startDate = period.startDate();
-        CountsAndSums cacheData = genderStatisticsCacheFetchService
-                .getSatisfactionAveragesEachGender(registerType);
+        CountsAndSums cacheData;
+        try {
+            cacheData = genderStatisticsCacheFetchService
+                    .getSatisfactionAveragesEachGender(registerType);
+        } catch (Exception e) {
+            log.warn("RegisterType(" + registerType
+                    + ") Error occurred while fetching cache data. Cache will be updated.", e);
+            CountsAndSums repositoryData = genderStatisticsRepositoryFetchService
+                    .getGenderSatisfactionCountsAndSums(registerType, startDate, endDate);
+            genderStatisticsCacheWriteService.putSatisfactionCountsAndSumsByGender(repositoryData, registerType);
+            return;
+        }
+
         CountsAndSums repositoryData = genderStatisticsRepositoryFetchService
                 .getGenderSatisfactionCountsAndSums(registerType, startDate, endDate);
-
         if (isNotSame(cacheData, repositoryData)) {
             log.warn("RegisterType(" + registerType
                     + ") GenderSatisfactionAverage Cache Data and Repository Data are not same. Cache will be updated.");

--- a/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
@@ -3,6 +3,7 @@ package com.example.spinlog.statistics.scheduled.startup;
 import com.example.spinlog.global.cache.HashCacheService;
 import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
+import com.example.spinlog.utils.StatisticsZeroPaddingUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -37,6 +38,7 @@ class GenderStatisticsCacheStartupService {
         LocalDate startDate = period.startDate();
 
         AllStatisticsMap allData = genderStatisticsRepositoryFetchService.getGenderStatisticsAllData(startDate, endDate);
+        allData = StatisticsZeroPaddingUtils.zeroPaddingAllStatisticsMap(allData, period);
 
         hashCacheService.putAllDataInHash(
                 getGenderEmotionStatisticsAmountSumKeyName(SPEND),

--- a/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
@@ -29,6 +29,9 @@ class GenderStatisticsCacheStartupService {
     public void initGenderStatisticsCache() {
         log.info("Start initializing Caching"); // todo put data with zero padding
 
+        statisticsPeriodManager.setStatisticsPeriodImmediatelyAfterSpringBootIsStarted();
+
+        // have to lock
         Period period = statisticsPeriodManager.getStatisticsPeriod();
         LocalDate endDate = period.endDate();
         LocalDate startDate = period.startDate();

--- a/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
@@ -1,0 +1,73 @@
+package com.example.spinlog.statistics.scheduled.startup;
+
+import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
+import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+import static com.example.spinlog.article.entity.RegisterType.SAVE;
+import static com.example.spinlog.article.entity.RegisterType.SPEND;
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
+import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.AllStatisticsMap;
+import static com.example.spinlog.utils.CacheKeyNameUtils.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+class GenderStatisticsCacheStartupService {
+    private final HashCacheService hashCacheService;
+    private final GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void initGenderStatisticsCache() {
+        log.info("Start initializing Caching");
+
+        Period period = statisticsPeriodManager.getStatisticsPeriod();
+        LocalDate endDate = period.endDate();
+        LocalDate startDate = period.startDate();
+
+        AllStatisticsMap allData = genderStatisticsRepositoryFetchService.getGenderStatisticsAllData(startDate, endDate);
+
+        hashCacheService.putAllDataInHash(
+                getGenderEmotionStatisticsAmountSumKeyName(SPEND),
+                allData.genderEmotionAmountSpendCountsAndSums().sumsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderEmotionStatisticsAmountCountKeyName(SPEND),
+                allData.genderEmotionAmountSpendCountsAndSums().countsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderEmotionStatisticsAmountSumKeyName(SAVE),
+                allData.genderEmotionAmountSaveCountsAndSums().sumsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderEmotionStatisticsAmountCountKeyName(SAVE),
+                allData.genderEmotionAmountSaveCountsAndSums().countsMap());
+
+        hashCacheService.putAllDataInHash(
+                getGenderDailyStatisticsAmountSumKeyName(SPEND),
+                allData.genderDailyAmountSpendSums());
+        hashCacheService.putAllDataInHash(
+                getGenderDailyStatisticsAmountSumKeyName(SAVE),
+                allData.genderDailyAmountSaveSums());
+
+        hashCacheService.putAllDataInHash(
+                getGenderStatisticsSatisfactionSumKeyName(SPEND),
+                allData.genderSatisfactionSpendCountsAndSums().sumsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderStatisticsSatisfactionCountKeyName(SPEND),
+                allData.genderSatisfactionSpendCountsAndSums().countsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderStatisticsSatisfactionSumKeyName(SAVE),
+                allData.genderSatisfactionSaveCountsAndSums().sumsMap());
+        hashCacheService.putAllDataInHash(
+                getGenderStatisticsSatisfactionCountKeyName(SAVE),
+                allData.genderSatisfactionSaveCountsAndSums().countsMap());
+
+        log.info("Finish initializing Caching");
+    }
+}

--- a/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
+++ b/src/main/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupService.java
@@ -27,7 +27,7 @@ class GenderStatisticsCacheStartupService {
 
     @EventListener(ApplicationReadyEvent.class)
     public void initGenderStatisticsCache() {
-        log.info("Start initializing Caching");
+        log.info("Start initializing Caching"); // todo put data with zero padding
 
         Period period = statisticsPeriodManager.getStatisticsPeriod();
         LocalDate endDate = period.endDate();

--- a/src/main/java/com/example/spinlog/statistics/service/fetch/GenderStatisticsRepositoryFetchService.java
+++ b/src/main/java/com/example/spinlog/statistics/service/fetch/GenderStatisticsRepositoryFetchService.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,6 +19,7 @@ import static com.example.spinlog.article.entity.RegisterType.*;
 import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class GenderStatisticsRepositoryFetchService {

--- a/src/main/java/com/example/spinlog/utils/StatisticsZeroPaddingUtils.java
+++ b/src/main/java/com/example/spinlog/utils/StatisticsZeroPaddingUtils.java
@@ -1,0 +1,152 @@
+package com.example.spinlog.utils;
+
+import com.example.spinlog.article.entity.Emotion;
+import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
+import com.example.spinlog.user.entity.Gender;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.Period;
+import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StatisticsZeroPaddingUtils {
+
+    public static CountsAndSums zeroPaddingToGenderEmotionAmountCountsAndSums(CountsAndSums countsAndSums) {
+        List<String> keys = getGenderEmotionKeys();
+        verifyKeys(countsAndSums, keys);
+
+        Map<String, Object> sumsMap = new HashMap<>();
+        Map<String, Object> countsMap = new HashMap<>();
+
+        keys.forEach(key -> {
+            countsMap.put(
+                    key,
+                    countsAndSums.countsMap()
+                            .getOrDefault(key, 0L));
+            sumsMap.put(
+                    key,
+                    countsAndSums.sumsMap()
+                            .getOrDefault(key, 0L));
+        });
+
+        return new CountsAndSums(sumsMap, countsMap);
+    }
+
+    public static Map<String, Object> zeroPaddingToGenderDailyAmountSums(Map<String, Object> sums, Period period) {
+        List<String> keys = getGenderDailyKeys(period);
+
+        verifyKeys(sums, keys);
+        Map<String, Object> sumsMap = new HashMap<>();
+
+        keys.forEach(key -> {
+            if (!sums.containsKey(key)) {
+                sums.put(key, 0L);
+            }
+            sumsMap.put(
+                    key,
+                    sums.getOrDefault(key, 0L));
+
+        });
+
+        return sumsMap;
+    }
+
+    public static CountsAndSums zeroPaddingToGenderSatisfactionAmountCountsAndSums(CountsAndSums countsAndSums) {
+        List<String> keys = getGenderKeys();
+        verifyKeys(countsAndSums, keys);
+
+        Map<String, Object> sumsMap = new HashMap<>();
+        Map<String, Object> countsMap = new HashMap<>();
+
+        keys.forEach(key -> {
+            countsMap.put(
+                    key,
+                    countsAndSums.countsMap()
+                            .getOrDefault(key, 0L));
+            sumsMap.put(
+                    key,
+                    countsAndSums.sumsMap()
+                            .getOrDefault(key, 0.0));
+        });
+
+        return new CountsAndSums(sumsMap, countsMap);
+    }
+
+    public static AllStatisticsMap zeroPaddingAllStatisticsMap(AllStatisticsMap allData, Period period) {
+        return AllStatisticsMap.builder()
+                .genderEmotionAmountSpendCountsAndSums(
+                        zeroPaddingToGenderEmotionAmountCountsAndSums(allData.genderEmotionAmountSpendCountsAndSums()))
+                .genderEmotionAmountSaveCountsAndSums(
+                        zeroPaddingToGenderEmotionAmountCountsAndSums(allData.genderEmotionAmountSaveCountsAndSums()))
+                .genderDailyAmountSpendSums(
+                        zeroPaddingToGenderDailyAmountSums(allData.genderDailyAmountSpendSums(), period))
+                .genderDailyAmountSaveSums(
+                        zeroPaddingToGenderDailyAmountSums(allData.genderDailyAmountSaveSums(), period))
+                .genderSatisfactionSpendCountsAndSums(
+                        zeroPaddingToGenderSatisfactionAmountCountsAndSums(allData.genderSatisfactionSpendCountsAndSums()))
+                .genderSatisfactionSaveCountsAndSums(
+                        zeroPaddingToGenderSatisfactionAmountCountsAndSums(allData.genderSatisfactionSaveCountsAndSums()))
+                .build();
+    }
+
+    private static List<String> getGenderEmotionKeys() {
+        List<String> keys = Arrays.stream(Gender.values())
+                .filter(g -> !g.equals(Gender.NONE))
+                .flatMap(g ->
+                        Arrays.stream(Emotion.values())
+                                .map(e -> g + "::" + e))
+                .toList();
+        return keys;
+    }
+
+    private static List<String> getGenderDailyKeys(Period period) {
+        LocalDate startDate = period.startDate();
+        LocalDate endDate = period.endDate();
+        List<String> keys = new ArrayList<>();
+        List<Gender> genders = Arrays.stream(Gender.values())
+                .filter(g -> !g.equals(Gender.NONE))
+                .toList();
+        for (LocalDate date = startDate; date.isBefore(endDate); date = date.plusDays(1)) {
+            String dateString = date.toString();
+            genders.forEach(g -> keys.add(g + "::" + dateString));
+        }
+        return keys;
+    }
+
+    private static List<String> getGenderKeys() {
+        List<String> keys = Arrays.stream(Gender.values())
+                .filter(g -> !g.equals(Gender.NONE))
+                .map(Gender::name)
+                .toList();
+        return keys;
+    }
+
+    private static void verifyKeys(CountsAndSums countsAndSums, List<String> keys) {
+        if(!countsAndSums.sumsMap().isEmpty()){
+            for(var e: countsAndSums.sumsMap().keySet()){
+                if(!keys.contains(e)){
+                    throw new IllegalArgumentException("Invalid key, countsAndSums: " + countsAndSums);
+                }
+            }
+            for(var e: countsAndSums.countsMap().keySet()){
+                if(!keys.contains(e)){
+                    throw new IllegalArgumentException("Invalid key, countsAndSums: " + countsAndSums);
+                }
+            }
+        }
+    }
+
+    private static void verifyKeys(Map<String, Object> sums, List<String> keys) {
+        if(!sums.isEmpty()){
+            for(var e: sums.keySet()){
+                if(!keys.contains(e)){
+                    throw new IllegalArgumentException("Invalid key, sums: " + sums);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,6 +38,10 @@ spring:
     hibernate:
       ddl-auto: validate
     open-in-view: false
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 logging:
   config: classpath:logback-dev.xml

--- a/src/test/java/com/example/spinlog/integration/GenderStatisticsCacheIntegrationTest.java
+++ b/src/test/java/com/example/spinlog/integration/GenderStatisticsCacheIntegrationTest.java
@@ -9,7 +9,7 @@ import com.example.spinlog.article.service.request.ArticleCreateRequest;
 import com.example.spinlog.article.service.request.ArticleUpdateRequest;
 import com.example.spinlog.article.service.response.WriteArticleResponseDto;
 import com.example.spinlog.statistics.repository.dto.GenderSatisfactionAverageDto;
-import com.example.spinlog.integration.init.GenderStatisticsCacheStartupService;
+import com.example.spinlog.integration.init.GenderStatisticsCacheSetupService;
 import com.example.spinlog.statistics.service.GenderStatisticsService;
 import com.example.spinlog.statistics.service.dto.GenderDailyAmountSumResponse;
 import com.example.spinlog.statistics.service.dto.GenderEmotionAmountAverageResponse;
@@ -17,7 +17,7 @@ import com.example.spinlog.user.entity.Gender;
 import com.example.spinlog.user.entity.User;
 import com.example.spinlog.user.repository.UserRepository;
 import com.example.spinlog.util.CacheConfiguration;
-import com.example.spinlog.integration.init.DataSetupService;
+import com.example.spinlog.integration.init.RepositoryDataSetupService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,9 +45,9 @@ public class GenderStatisticsCacheIntegrationTest {
     @Autowired
     GenderStatisticsService genderStatisticsService;
     @Autowired
-    GenderStatisticsCacheStartupService genderStatisticsCacheStartupService;
+    GenderStatisticsCacheSetupService genderStatisticsCacheSetupService;
     @Autowired
-    DataSetupService dataSetupService;
+    RepositoryDataSetupService repositoryDataSetupService;
 
     LocalDate spendDate = LocalDate.now().minusDays(1);
     Emotion emotion = Emotion.SAD;
@@ -61,8 +61,8 @@ public class GenderStatisticsCacheIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        dataSetupService.setUp();
-        genderStatisticsCacheStartupService.initGenderStatisticsCache();
+        repositoryDataSetupService.setUp();
+        genderStatisticsCacheSetupService.initGenderStatisticsCache();
     }
 
     @AfterEach

--- a/src/test/java/com/example/spinlog/integration/GenderStatisticsCacheUserWriteIntegrationTest.java
+++ b/src/test/java/com/example/spinlog/integration/GenderStatisticsCacheUserWriteIntegrationTest.java
@@ -5,9 +5,9 @@ import com.example.spinlog.article.entity.RegisterType;
 import com.example.spinlog.article.repository.ArticleRepository;
 import com.example.spinlog.global.security.customFilter.OAuth2ResponseImpl;
 import com.example.spinlog.global.security.oauth2.user.CustomOAuth2User;
-import com.example.spinlog.integration.init.DataSetupService;
+import com.example.spinlog.integration.init.RepositoryDataSetupService;
 import com.example.spinlog.statistics.repository.dto.GenderSatisfactionAverageDto;
-import com.example.spinlog.integration.init.GenderStatisticsCacheStartupService;
+import com.example.spinlog.integration.init.GenderStatisticsCacheSetupService;
 import com.example.spinlog.statistics.service.GenderStatisticsService;
 import com.example.spinlog.statistics.service.dto.GenderDailyAmountSumResponse;
 import com.example.spinlog.statistics.service.dto.GenderEmotionAmountAverageResponse;
@@ -47,9 +47,9 @@ public class GenderStatisticsCacheUserWriteIntegrationTest {
     GenderStatisticsService genderStatisticsService;
 
     @Autowired
-    GenderStatisticsCacheStartupService genderStatisticsCacheStartupService;
+    GenderStatisticsCacheSetupService genderStatisticsCacheSetupService;
     @Autowired
-    DataSetupService dataSetupService;
+    RepositoryDataSetupService repositoryDataSetupService;
 
     LocalDate spendDate = LocalDate.now().minusDays(1);
     Emotion emotion = Emotion.SAD;
@@ -63,8 +63,8 @@ public class GenderStatisticsCacheUserWriteIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        dataSetupService.setUp();
-        genderStatisticsCacheStartupService.initGenderStatisticsCache();
+        repositoryDataSetupService.setUp();
+        genderStatisticsCacheSetupService.initGenderStatisticsCache();
     }
 
     @AfterEach

--- a/src/test/java/com/example/spinlog/integration/init/GenderStatisticsCacheSetupService.java
+++ b/src/test/java/com/example/spinlog/integration/init/GenderStatisticsCacheSetupService.java
@@ -1,6 +1,7 @@
 package com.example.spinlog.integration.init;
 
 import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
 import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,14 +19,17 @@ import static com.example.spinlog.utils.StatisticsCacheUtils.*;
 @Transactional(readOnly = true) // todo 범위 좁히기
 @RequiredArgsConstructor
 @Slf4j
-public class GenderStatisticsCacheStartupService {
+public class GenderStatisticsCacheSetupService {
     private final HashCacheService hashCacheService;
     private final GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService;
+    private final StatisticsPeriodManager statisticsPeriodManager;
 
     public void initGenderStatisticsCache() {
-        log.info("Start initializing Caching to Redis");
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(PERIOD_CRITERIA);
+        log.info("Start initializing Caching");
+
+        StatisticsPeriodManager.Period period = statisticsPeriodManager.getStatisticsPeriod();
+        LocalDate endDate = period.endDate();
+        LocalDate startDate = period.startDate();
 
         AllStatisticsMap allData = genderStatisticsRepositoryFetchService.getGenderStatisticsAllData(startDate, endDate);
 
@@ -62,6 +66,6 @@ public class GenderStatisticsCacheStartupService {
                 getGenderStatisticsSatisfactionCountKeyName(SAVE),
                 allData.genderSatisfactionSaveCountsAndSums().countsMap());
 
-        log.info("Finish initializing Caching to Redis");
+        log.info("Finish initializing Caching");
     }
 }

--- a/src/test/java/com/example/spinlog/integration/init/RepositoryDataSetupService.java
+++ b/src/test/java/com/example/spinlog/integration/init/RepositoryDataSetupService.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class DataSetupService {
+public class RepositoryDataSetupService {
     private final ArticleRepository articleRepository;
     private final UserRepository userRepository;
 

--- a/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/GenderStatisticsCacheVerifyScheduledServiceTest.java
@@ -38,6 +38,28 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
     @Nested
     class updateGenderEmotionAmountAverageCacheIfCacheMiss {
         @Test
+        void 캐시로부터_데이터를_받을_때_에러가_발생한다면_레포지토리의_데이터를_요청한_다음_캐시를_업데이트한다() throws Exception {
+            // given
+            when(genderStatisticsCacheFetchService.getAmountAveragesEachGenderAndEmotion(any()))
+                    .thenThrow(new RuntimeException());
+
+            CountsAndSums repositoryData = new CountsAndSums(
+                    Map.of("key1", 1, "key2", 2),
+                    Map.of("key1", 1, "key2", 100));
+            when(genderStatisticsRepositoryFetchService.getGenderEmotionAmountCountsAndSums(any(), any(), any()))
+                    .thenReturn(repositoryData);
+
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
+            // when
+            targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND, period);
+
+            // then
+            verify(genderStatisticsRepositoryFetchService).getGenderEmotionAmountCountsAndSums(any(), any(), any());
+            verify(genderStatisticsCacheWriteService).putAmountCountsAndSumsByGenderAndEmotion(eq(repositoryData), any());
+        }
+
+        @Test
         void 캐시와_레포지토리로부터_받은_데이터가_같다면_CacheWriteService를_호출하지_않는다() throws Exception {
             // given
             when(genderStatisticsCacheFetchService.getAmountAveragesEachGenderAndEmotion(any()))
@@ -65,10 +87,11 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                     .thenReturn(new CountsAndSums(
                             Map.of("key1", 1, "key2", 2),
                             Map.of("key1", 1, "key2", 2)));
+            CountsAndSums repositoryData = new CountsAndSums(
+                    Map.of("key1", 1, "key2", 2),
+                    Map.of("key1", 1, "key2", 100));
             when(genderStatisticsRepositoryFetchService.getGenderEmotionAmountCountsAndSums(any(), any(), any()))
-                    .thenReturn(new CountsAndSums(
-                            Map.of("key1", 1, "key2", 2),
-                            Map.of("key1", 1, "key2", 100)));
+                    .thenReturn(repositoryData);
 
             Period period = statisticsPeriodManager.getStatisticsPeriod();
 
@@ -76,12 +99,32 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
             targetService.updateGenderEmotionAmountAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
-            verify(genderStatisticsCacheWriteService).putAmountCountsAndSumsByGenderAndEmotion(any(), any());
+            verify(genderStatisticsCacheWriteService).putAmountCountsAndSumsByGenderAndEmotion(eq(repositoryData), any());
         }
     }
 
     @Nested
     class updateGenderDailyAmountSumCacheIfCacheMiss {
+        @Test
+        void 캐시로부터_데이터를_받을_때_에러가_발생한다면_레포지토리의_데이터를_요청한_다음_캐시를_업데이트한다() throws Exception {
+            // given
+            when(genderStatisticsCacheFetchService.getAmountSumsEachGenderAndDay(any()))
+                    .thenThrow(new RuntimeException());
+
+            Map<String, Object> repositoryData = Map.of("key1", 1, "key2", 100);
+            when(genderStatisticsRepositoryFetchService.getGenderDateAmountSums(any(), any(), any()))
+                    .thenReturn(repositoryData);
+
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
+            // when
+            targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND, period);
+
+            // then
+            verify(genderStatisticsRepositoryFetchService).getGenderDateAmountSums(any(), any(), any());
+            verify(genderStatisticsCacheWriteService).putAmountSumsByGenderAndDate(eq(repositoryData), any());
+        }
+
         @Test
         void 캐시와_레포지토리로부터_받은_데이터가_같다면_CacheWriteService를_호출하지_않는다() throws Exception {
             // given
@@ -107,9 +150,10 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
             when(genderStatisticsCacheFetchService.getAmountSumsEachGenderAndDay(any()))
                     .thenReturn(
                             Map.of("key1", 1, "key2", 2));
+            Map<String, Object> repositoryData = Map.of("key1", 1, "key2", 100);
             when(genderStatisticsRepositoryFetchService.getGenderDateAmountSums(any(), any(), any()))
                     .thenReturn(
-                            Map.of("key1", 1, "key2", 100));
+                            repositoryData);
 
             Period period = statisticsPeriodManager.getStatisticsPeriod();
 
@@ -117,12 +161,32 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
             targetService.updateGenderDailyAmountSumCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
-            verify(genderStatisticsCacheWriteService).putAmountSumsByGenderAndDate(any(), any());
+            verify(genderStatisticsCacheWriteService).putAmountSumsByGenderAndDate(eq(repositoryData), any());
         }
     }
 
     @Nested
     class updateGenderSatisfactionAverageCacheIfCacheMiss {
+        @Test
+        void 캐시로부터_데이터를_받을_때_에러가_발생한다면_레포지토리의_데이터를_요청한_다음_캐시를_업데이트한다() throws Exception {
+            // given
+            when(genderStatisticsCacheFetchService.getSatisfactionAveragesEachGender(any()))
+                    .thenThrow(new RuntimeException());
+            CountsAndSums repositoryData = new CountsAndSums(
+                    Map.of("key1", 1.0, "key2", 2.0),
+                    Map.of("key1", 1, "key2", 100));
+            when(genderStatisticsRepositoryFetchService.getGenderSatisfactionCountsAndSums(any(), any(), any()))
+                    .thenReturn(repositoryData);
+
+            Period period = statisticsPeriodManager.getStatisticsPeriod();
+
+            // when
+            targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND, period);
+
+            // then
+            verify(genderStatisticsRepositoryFetchService).getGenderSatisfactionCountsAndSums(any(), any(), any());
+            verify(genderStatisticsCacheWriteService).putSatisfactionCountsAndSumsByGender(eq(repositoryData), any());
+        }
         @Test
         void 캐시와_레포지토리로부터_받은_데이터가_같다면_CacheWriteService를_호출하지_않는다() throws Exception {
             // given
@@ -151,10 +215,11 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
                     .thenReturn(new CountsAndSums(
                             Map.of("key1", 1.0, "key2", 2.0),
                             Map.of("key1", 1, "key2", 2)));
+            CountsAndSums repositoryData = new CountsAndSums(
+                    Map.of("key1", 1.0, "key2", 2.0),
+                    Map.of("key1", 1, "key2", 100));
             when(genderStatisticsRepositoryFetchService.getGenderSatisfactionCountsAndSums(any(), any(), any()))
-                    .thenReturn(new CountsAndSums(
-                            Map.of("key1", 1.0, "key2", 2.0),
-                            Map.of("key1", 1, "key2", 100)));
+                    .thenReturn(repositoryData);
 
             Period period = statisticsPeriodManager.getStatisticsPeriod();
 
@@ -162,7 +227,7 @@ class GenderStatisticsCacheVerifyScheduledServiceTest {
             targetService.updateGenderSatisfactionAverageCacheIfCacheMiss(RegisterType.SPEND, period);
 
             // then
-            verify(genderStatisticsCacheWriteService).putSatisfactionCountsAndSumsByGender(any(), any());
+            verify(genderStatisticsCacheWriteService).putSatisfactionCountsAndSumsByGender(eq(repositoryData), any());
         }
     }
 }

--- a/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceSetPeriodTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceSetPeriodTest.java
@@ -1,0 +1,78 @@
+package com.example.spinlog.statistics.scheduled.startup;
+
+import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.repository.GenderStatisticsRepository;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
+import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class GenderStatisticsCacheStartupServiceSetPeriodTest {
+    GenderStatisticsRepository genderStatisticsRepository = mock(GenderStatisticsRepository.class);
+    GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService =
+            new GenderStatisticsRepositoryFetchService(genderStatisticsRepository);
+    HashCacheService hashCacheService = mock(HashCacheService.class);
+
+    @ParameterizedTest
+    @ValueSource(strings = {"00:00:00", "03:59:59"})
+    void 오전_4시_이전에_실행되면_어제를_기준으로_Statistics_Period가_세팅된다(String localTime) throws Exception {
+        // given
+        Clock clock = getFixedClock(localTime);
+        StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(clock);
+
+        GenderStatisticsCacheStartupService genderStatisticsStartupService =
+                new GenderStatisticsCacheStartupService(
+                        hashCacheService,
+                        genderStatisticsRepositoryFetchService,
+                        statisticsPeriodManager);
+
+        // when
+        genderStatisticsStartupService.initGenderStatisticsCache();
+
+        // then
+        StatisticsPeriodManager.Period period = statisticsPeriodManager.getStatisticsPeriod();
+
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        assertThat(period.startDate()).isEqualTo(yesterday.minusDays(30));
+        assertThat(period.endDate()).isEqualTo(yesterday);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"04:00:00", "23:59:59"})
+    void 오전_4시_이후에_실행되면_오늘을_기준으로_Statistics_Period가_세팅된다(String localTime) throws Exception {
+        // given
+        Clock clock = getFixedClock(localTime);
+        StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(clock);
+
+        GenderStatisticsCacheStartupService genderStatisticsStartupService =
+                new GenderStatisticsCacheStartupService(
+                        hashCacheService,
+                        genderStatisticsRepositoryFetchService,
+                        statisticsPeriodManager);
+
+        // when
+        genderStatisticsStartupService.initGenderStatisticsCache();
+
+        // then
+        StatisticsPeriodManager.Period period = statisticsPeriodManager.getStatisticsPeriod();
+
+        LocalDate today = LocalDate.now();
+        assertThat(period.startDate()).isEqualTo(today.minusDays(30));
+        assertThat(period.endDate()).isEqualTo(today);
+    }
+
+    private static Clock getFixedClock(String instant) {
+        String now = LocalDate.now().toString();
+        LocalDateTime localDateTime = LocalDateTime.of(LocalDate.now(), LocalTime.parse(instant));
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+        return Clock.fixed(
+                zonedDateTime.toInstant(),
+                ZoneId.systemDefault());
+    }
+
+}

--- a/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -30,10 +31,14 @@ class GenderStatisticsCacheStartupServiceTest {
     GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService =
             new GenderStatisticsRepositoryFetchService(genderStatisticsRepository);
     HashCacheService hashCacheService = new MockHashCacheService();
+
+    // todo set fixed clock and test
     StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
 
     GenderStatisticsCacheStartupService genderStatisticsStartupService =
             new GenderStatisticsCacheStartupService(hashCacheService, genderStatisticsRepositoryFetchService, statisticsPeriodManager);
+
+
 
     @Test
     @DisplayName("레포지토리로부터 통계 데이터를 받아 캐시에 저장한다.")
@@ -61,32 +66,79 @@ class GenderStatisticsCacheStartupServiceTest {
         genderStatisticsStartupService.initGenderStatisticsCache();
 
         // then
+        List<String> keys = List.of("MALE::PROUD", "MALE::SAD", "FEMALE::PROUD", "FEMALE::SAD");
+        List<Long> amounts = List.of(1L, 2L, 3L, 4L);
         Map<String, Object> genderEmotionAmountSums = hashCacheService.getHashEntries(
                 getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND));
-        assertThat(genderEmotionAmountSums.size()).isEqualTo(4);
-        assertThat(genderEmotionAmountSums.get("MALE::PROUD")).isEqualTo(1L);
-        assertThat(genderEmotionAmountSums.get("MALE::SAD")).isEqualTo(2L);
-        assertThat(genderEmotionAmountSums.get("FEMALE::PROUD")).isEqualTo(3L);
-        assertThat(genderEmotionAmountSums.get("FEMALE::SAD")).isEqualTo(4L);
-
-        assertThat(hashCacheService.getHashEntries(getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SAVE)))
-                .hasSize(0);
+        for(var key: keys){
+            assertThat(genderEmotionAmountSums.get(key)).isNotNull();
+            assertThat(genderEmotionAmountSums.get(key)).isInstanceOf(Long.class)
+                    .isEqualTo(amounts.get(keys.indexOf(key)));
+        }
 
         Map<String, Object> genderEmotionAmountCounts = hashCacheService.getHashEntries(
                 getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND));
-        assertThat(genderEmotionAmountCounts.size()).isEqualTo(4);
-        assertThat(genderEmotionAmountCounts.get("MALE::PROUD")).isEqualTo(1L);
-        assertThat(genderEmotionAmountCounts.get("MALE::SAD")).isEqualTo(1L);
-        assertThat(genderEmotionAmountCounts.get("FEMALE::PROUD")).isEqualTo(1L);
-        assertThat(genderEmotionAmountCounts.get("FEMALE::SAD")).isEqualTo(1L);
 
-        for (String key : getAllCacheKeyNames()) {
-            if (key.equals(getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND)) ||
-                    key.equals(getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND)))
-                continue;
-            assertThat(hashCacheService.getHashEntries(key).size()).isZero();
+        for (var key: keys) {
+            assertThat(genderEmotionAmountCounts.get(key)).isNotNull();
+            assertThat(genderEmotionAmountCounts.get(key)).isInstanceOf(Long.class)
+                    .isEqualTo(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("레포지토리로부터 통계 데이터를 받아 캐시에 제로 패딩을 한 후 저장한다.")
+    void startup_test_zero_padding() throws Exception {
+        // given
+        List<GenderEmotionAmountAverageDto> returned = List.of(
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.SAD, 2L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.PROUD, 3L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.SAD, 4L)
+        );
+        List<GenderEmotionAmountAverageDto> counts = List.of(
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.SAD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.SAD, 1L)
+        );
+
+        when(genderStatisticsRepository.getAmountSumsEachGenderAndEmotionBetweenStartDateAndEndDate(eq(RegisterType.SPEND), any() , any()))
+                .thenReturn(returned);
+        when(genderStatisticsRepository.getAmountCountsEachGenderAndEmotionBetweenStartDateAndEndDate(eq(RegisterType.SPEND), any() , any()))
+                .thenReturn(counts);
+
+        // when
+        genderStatisticsStartupService.initGenderStatisticsCache();
+
+        // then
+        List<String> keys = List.of("MALE::PROUD", "MALE::SAD", "FEMALE::PROUD", "FEMALE::SAD");
+        Map<String, Object> genderEmotionAmountSums = hashCacheService.getHashEntries(
+                getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND));
+        for(var key: genderEmotionAmountSums.keySet()){
+            if(keys.contains(key)) continue;
+            assertThat(genderEmotionAmountSums.get(key)).isEqualTo(0L);
         }
 
+        Map<String, Object> genderEmotionAmountCounts = hashCacheService.getHashEntries(
+                getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND));
+        for(var key: genderEmotionAmountCounts.keySet()){
+            if(keys.contains(key)) continue;
+            assertThat(genderEmotionAmountSums.get(key)).isEqualTo(0L);
+        }
+
+        for(var key: getAllCacheKeyNames()) {
+            if(key.equals(getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND)) ||
+                    key.equals(getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND))) continue;
+            Map<String, Object> entries = hashCacheService.getHashEntries(key);
+            for(var e: entries.entrySet()){
+                if(e.getValue() instanceof Double){
+                    assertThat(e.getValue()).isEqualTo(0.0);
+                }
+                else
+                    assertThat(e.getValue()).isEqualTo(0L);
+            }
+        }
     }
 
     private String[] getAllCacheKeyNames(){

--- a/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceTest.java
+++ b/src/test/java/com/example/spinlog/statistics/scheduled/startup/GenderStatisticsCacheStartupServiceTest.java
@@ -1,0 +1,107 @@
+package com.example.spinlog.statistics.scheduled.startup;
+
+import com.example.spinlog.article.entity.Emotion;
+import com.example.spinlog.article.entity.RegisterType;
+import com.example.spinlog.global.cache.HashCacheService;
+import com.example.spinlog.statistics.repository.GenderStatisticsRepository;
+import com.example.spinlog.statistics.repository.dto.GenderEmotionAmountAverageDto;
+import com.example.spinlog.statistics.service.StatisticsPeriodManager;
+import com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService;
+import com.example.spinlog.user.entity.Gender;
+import com.example.spinlog.util.MockHashCacheService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+
+import static com.example.spinlog.utils.CacheKeyNameUtils.*;
+import static com.example.spinlog.utils.CacheKeyNameUtils.getGenderStatisticsSatisfactionCountKeyName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GenderStatisticsCacheStartupServiceTest {
+    GenderStatisticsRepository genderStatisticsRepository = mock(GenderStatisticsRepository.class);
+    GenderStatisticsRepositoryFetchService genderStatisticsRepositoryFetchService =
+            new GenderStatisticsRepositoryFetchService(genderStatisticsRepository);
+    HashCacheService hashCacheService = new MockHashCacheService();
+    StatisticsPeriodManager statisticsPeriodManager = new StatisticsPeriodManager(Clock.systemDefaultZone());
+
+    GenderStatisticsCacheStartupService genderStatisticsStartupService =
+            new GenderStatisticsCacheStartupService(hashCacheService, genderStatisticsRepositoryFetchService, statisticsPeriodManager);
+
+    @Test
+    @DisplayName("레포지토리로부터 통계 데이터를 받아 캐시에 저장한다.")
+    void startup_test() throws Exception {
+        // given
+        List<GenderEmotionAmountAverageDto> returned = List.of(
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.SAD, 2L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.PROUD, 3L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.SAD, 4L)
+        );
+        List<GenderEmotionAmountAverageDto> counts = List.of(
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.MALE, Emotion.SAD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.PROUD, 1L),
+                new GenderEmotionAmountAverageDto(Gender.FEMALE, Emotion.SAD, 1L)
+        );
+
+        when(genderStatisticsRepository.getAmountSumsEachGenderAndEmotionBetweenStartDateAndEndDate(eq(RegisterType.SPEND), any() , any()))
+                .thenReturn(returned);
+        when(genderStatisticsRepository.getAmountCountsEachGenderAndEmotionBetweenStartDateAndEndDate(eq(RegisterType.SPEND), any() , any()))
+                .thenReturn(counts);
+
+        // when
+        genderStatisticsStartupService.initGenderStatisticsCache();
+
+        // then
+        Map<String, Object> genderEmotionAmountSums = hashCacheService.getHashEntries(
+                getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND));
+        assertThat(genderEmotionAmountSums.size()).isEqualTo(4);
+        assertThat(genderEmotionAmountSums.get("MALE::PROUD")).isEqualTo(1L);
+        assertThat(genderEmotionAmountSums.get("MALE::SAD")).isEqualTo(2L);
+        assertThat(genderEmotionAmountSums.get("FEMALE::PROUD")).isEqualTo(3L);
+        assertThat(genderEmotionAmountSums.get("FEMALE::SAD")).isEqualTo(4L);
+
+        assertThat(hashCacheService.getHashEntries(getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SAVE)))
+                .hasSize(0);
+
+        Map<String, Object> genderEmotionAmountCounts = hashCacheService.getHashEntries(
+                getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND));
+        assertThat(genderEmotionAmountCounts.size()).isEqualTo(4);
+        assertThat(genderEmotionAmountCounts.get("MALE::PROUD")).isEqualTo(1L);
+        assertThat(genderEmotionAmountCounts.get("MALE::SAD")).isEqualTo(1L);
+        assertThat(genderEmotionAmountCounts.get("FEMALE::PROUD")).isEqualTo(1L);
+        assertThat(genderEmotionAmountCounts.get("FEMALE::SAD")).isEqualTo(1L);
+
+        for (String key : getAllCacheKeyNames()) {
+            if (key.equals(getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND)) ||
+                    key.equals(getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND)))
+                continue;
+            assertThat(hashCacheService.getHashEntries(key).size()).isZero();
+        }
+
+    }
+
+    private String[] getAllCacheKeyNames(){
+        return new String[]{
+                getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SPEND),
+                getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SPEND),
+                getGenderEmotionStatisticsAmountSumKeyName(RegisterType.SAVE),
+                getGenderEmotionStatisticsAmountCountKeyName(RegisterType.SAVE),
+                getGenderDailyStatisticsAmountSumKeyName(RegisterType.SPEND),
+                getGenderDailyStatisticsAmountSumKeyName(RegisterType.SAVE),
+                getGenderStatisticsSatisfactionSumKeyName(RegisterType.SPEND),
+                getGenderStatisticsSatisfactionCountKeyName(RegisterType.SPEND),
+                getGenderStatisticsSatisfactionSumKeyName(RegisterType.SAVE),
+                getGenderStatisticsSatisfactionCountKeyName(RegisterType.SAVE)
+        };
+    }
+
+}

--- a/src/test/java/com/example/spinlog/util/MockHashCacheService.java
+++ b/src/test/java/com/example/spinlog/util/MockHashCacheService.java
@@ -2,10 +2,16 @@ package com.example.spinlog.util;
 
 import com.example.spinlog.global.cache.HashCacheService;
 import com.example.spinlog.statistics.exception.InvalidCacheException;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
+@Primary
+@Profile("test")
 public class MockHashCacheService implements HashCacheService {
     Map<String, Map<String, Object>> cache = new HashMap<>();
     @Override

--- a/src/test/java/com/example/spinlog/utils/StatisticsZeroPaddingUtilsTest.java
+++ b/src/test/java/com/example/spinlog/utils/StatisticsZeroPaddingUtilsTest.java
@@ -1,0 +1,189 @@
+package com.example.spinlog.utils;
+
+import com.example.spinlog.article.entity.Emotion;
+import com.example.spinlog.user.entity.Gender;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static com.example.spinlog.statistics.service.StatisticsPeriodManager.*;
+import static com.example.spinlog.statistics.service.fetch.GenderStatisticsRepositoryFetchService.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StatisticsZeroPaddingUtilsTest {
+    @Nested
+    class zeroPaddingToGenderEmotionAmountCountsAndSums {
+        @Test
+        void GenderEmotionAmountCountsAndSums에_대해_zero_padding을_수행한다() throws Exception {
+            // given
+            Map<String, Object> sumsMap = new HashMap<>();
+            sumsMap.put("MALE::SAD", 10L);
+            Map<String, Object> countsMap = new HashMap<>();
+            countsMap.put("MALE::SAD", 1L);
+            CountsAndSums countsAndSums = new CountsAndSums(sumsMap, countsMap);
+
+            // when
+            countsAndSums = StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderEmotionAmountCountsAndSums(countsAndSums);
+
+            // then
+            List<String> genderEmotionKeys = getGenderEmotionKeys();
+            assertThat(countsAndSums.countsMap().size()).isEqualTo(genderEmotionKeys.size());
+            assertThat(countsAndSums.sumsMap().size()).isEqualTo(genderEmotionKeys.size());
+
+            for (var key : genderEmotionKeys) {
+                if (key.equals("MALE::SAD")) {
+                    assertThat(countsAndSums.sumsMap().get(key)).isEqualTo(10L);
+                    assertThat(countsAndSums.countsMap().get(key)).isEqualTo(1L);
+                } else {
+                    assertThat(countsAndSums.sumsMap().get(key)).isEqualTo(0L);
+                    assertThat(countsAndSums.countsMap().get(key)).isEqualTo(0L);
+                }
+            }
+        }
+
+        @Test
+        void 유효하지_않은_키가_있다면_실패한다() throws Exception {
+            // given
+            Map<String, Object> sumsMap = new HashMap<>();
+            sumsMap.put("MAL::SAD", 10L);
+            Map<String, Object> countsMap = new HashMap<>();
+            countsMap.put("MALE::SADD", 1L);
+            CountsAndSums countsAndSums = new CountsAndSums(sumsMap, countsMap);
+
+            // when // then
+            assertThatThrownBy(() -> StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderEmotionAmountCountsAndSums(countsAndSums))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        private List<String> getGenderEmotionKeys() {
+            return Arrays.stream(Gender.values())
+                    .filter(g -> !g.equals(Gender.NONE))
+                    .flatMap(g ->
+                            Arrays.stream(Emotion.values())
+                                    .map(e -> g + "::" + e))
+                    .toList();
+        }
+    }
+
+    @Nested
+    class zeroPaddingToGenderDailyAmountSums {
+        @Test
+        void GenderDailyAmountSums에_대해_zero_padding을_수행한다() throws Exception {
+            // given
+            Map<String, Object> sums = new HashMap<>();
+            sums.put("MALE::2021-01-01", 10L);
+            Period period = new Period(
+                    LocalDate.of(2021, 1, 1),
+                    LocalDate.of(2021, 1, 3));
+
+            // when
+            sums = StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderDailyAmountSums(sums, period);
+
+            // then
+            List<String> genderDailyAmountKeys = getGenderDailyKeys(period);
+            assertThat(sums.size()).isEqualTo(genderDailyAmountKeys.size());
+            for(var key : genderDailyAmountKeys){
+                if(key.equals("MALE::2021-01-01")){
+                    assertThat(sums.get(key)).isEqualTo(10L);
+                } else {
+                    assertThat(sums.get(key)).isEqualTo(0L);
+                }
+            }
+        }
+
+        @Test
+        void 유효하지_않은_키가_있다면_실패한다() throws Exception {
+            // given
+            Map<String, Object> sums = new HashMap<>();
+            sums.put("MALE::22021-01-01", 10L);
+            Period period = new Period(
+                    LocalDate.of(2021, 1, 1),
+                    LocalDate.of(2021, 1, 3));
+
+            // when // then
+            assertThatThrownBy(() -> StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderDailyAmountSums(sums, period))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        private List<String> getGenderDailyKeys(Period period) {
+            LocalDate startDate = period.startDate();
+            LocalDate endDate = period.endDate();
+            List<Gender> genders = Arrays.stream(Gender.values())
+                    .filter(g -> !g.equals(Gender.NONE))
+                    .toList();
+            List<String> list = new ArrayList<>();
+            for (LocalDate date = startDate; date.isBefore(endDate); date = date.plusDays(1)) {
+                list.add("MALE::" + date);
+                list.add("FEMALE::" + date);
+            }
+            return list;
+        }
+
+    }
+
+    @Nested
+    class zeroPaddingToGenderSatisfactionAmountCountsAndSums {
+        @Test
+        void GenderSatisfactionAmountCountsAndSums에_대해_zero_padding을_수행한다() throws Exception {
+            // given
+            Map<String, Object> sumsMap = new HashMap<>();
+            sumsMap.put("MALE", 10.0);
+            Map<String, Object> countsMap = new HashMap<>();
+            countsMap.put("MALE", 2L);
+            CountsAndSums countsAndSums = new CountsAndSums(sumsMap, countsMap);
+
+            // when
+            countsAndSums = StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderSatisfactionAmountCountsAndSums(countsAndSums);
+
+            // then
+            List<String> keys = getGenderKeys();
+            assertThat(countsAndSums.countsMap().size()).isEqualTo(keys.size());
+            assertThat(countsAndSums.sumsMap().size()).isEqualTo(keys.size());
+
+            for (var key : keys) {
+                if (key.equals("MALE")) {
+                    assertThat(countsAndSums.sumsMap().get(key)).isEqualTo(10.0);
+                    assertThat(countsAndSums.countsMap().get(key)).isEqualTo(2L);
+                } else {
+                    assertThat(countsAndSums.sumsMap().get(key)).isEqualTo(0.0);
+                    assertThat(countsAndSums.countsMap().get(key)).isEqualTo(0L);
+                }
+            }
+        }
+
+        @Test
+        void 유효하지_않은_키가_있다면_실패한다() throws Exception {
+            // given
+            Map<String, Object> sumsMap = new HashMap<>();
+            sumsMap.put("MALEE", 10.0);
+            Map<String, Object> countsMap = new HashMap<>();
+            countsMap.put("MALE", 2L);
+            CountsAndSums countsAndSums = new CountsAndSums(sumsMap, countsMap);
+
+            // when // then
+            assertThatThrownBy(() -> StatisticsZeroPaddingUtils
+                    .zeroPaddingToGenderSatisfactionAmountCountsAndSums(countsAndSums))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        private List<String> getGenderKeys() {
+            List<String> keys = Arrays.stream(Gender.values())
+                    .filter(g -> !g.equals(Gender.NONE))
+                    .map(Gender::name)
+                    .toList();
+            return keys;
+        }
+    }
+}


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요? 🔍
성별 통계 캐시 관련 기능 리팩토링


## 어떻게 해결했나요? ✏️
1. 모든 통계 관련 클래스들에서 StatisticsPeriodManager에 대한 dependency 추가 
& StatisticsPeriodManager로부터 통계 기간에 대한 LocalDate 쌍을 받는다.
이 변수를 가지고 통계 데이터를 레포지토리나 캐시로부터 얻는다.
2. GenderStatisticsCacheStartupService 클래스 추가
이 클래스는 스프링 부트 시작시 StatisticsPeriodManager의 period를 세팅한다.
그리고 캐시를 레포지토리에 있는 데이터로 업데이트한다.
3. GenderStatsticsVerifyScheduledService에서 캐시 조회 실패 시 레포지토리 조회해서 캐시 업데이트하도록 리팩토링
4. MockHashCacheService를 test profile 일때만 스프링 빈으로 등록되도록 세팅
& @Primary 어노테이션을 통해 테스트 시 이 빈의 우선순위를 높인다.
5. 레디스 세팅을 위한 host와 port 정보 yml 파일에 추가

## 이슈 번호 ✅



## 추가 설명 (Optional) 📖

