### PR TITLE
fix: add zero padding to new date field from redis on GenderStatisticsCacheRefreshScheduledService

### DIFF
--- a/src/test/java/com/example/spinlog/util/MockHashCacheService.java
+++ b/src/test/java/com/example/spinlog/util/MockHashCacheService.java
@@ -96,7 +96,8 @@ public class MockHashCacheService implements HashCacheService {
 
     @Override
     public void deleteHashKey(String key, String hashKey) {
-        cache.get(key).remove(hashKey);
+        if(cache.containsKey(key))
+            cache.get(key).remove(hashKey);
     }
 
     public void clear(){


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요? 🔍
GenderStatisticsCacheRefreshScheduledService에서 캐시 데이터 업데이트 할 때
GenderDailyAmountSum 관련 데이터 업데이트 안되는 문제 해결


## 어떻게 해결했나요? ✏️
30일 전 데이터 직접 delete 하고, 어제 데이터 직접 추가하는 메서드 추가


## 이슈 번호 ✅



## 추가 설명 (Optional) 📖

