### PR TITLE
hotfix: integrate test config to remove creating duplicate view

### DIFF
--- a/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryQueryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryQueryTest.java
@@ -31,12 +31,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Slf4j
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class MBTIStatisticsRepositoryQueryTest {
+public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryTestSupport {
     @Autowired
     MBTIStatisticsRepository mbtiStatisticsRepository;
     @Autowired
@@ -54,11 +49,7 @@ public class MBTIStatisticsRepositoryQueryTest {
     static User user2;
 
     @BeforeAll
-    static void setUp(@Autowired DataSource dataSource, @Autowired UserRepository userRepository, @Autowired ArticleRepository articleRepository) {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScript(new ClassPathResource("view/before-test-schema.sql"));
-        populator.execute(dataSource);
-
+    static void setUp(@Autowired UserRepository userRepository, @Autowired ArticleRepository articleRepository) {
         user1 = User.builder()
                 .email("survived@email")
                 .authenticationName("survivedUser")

--- a/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryTest.java
@@ -30,12 +30,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Slf4j
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class MBTIStatisticsRepositoryTest {
+class MBTIStatisticsRepositoryTest extends MBTIStatisticsRepositoryTestSupport{
     @Autowired
     MBTIStatisticsRepository mbtiStatisticsRepository;
 
@@ -64,16 +59,6 @@ class MBTIStatisticsRepositoryTest {
     );
 
     LocalDate startDate, endDate;
-
-    /**
-     * JPA에서 등록된 엔티티를 테이블로 생성 해주지만, 뷰는 생성 안되서, sql 파일로 직접 생성
-     * */
-    @BeforeAll
-    public static void createView(@Autowired DataSource dataSource) {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScript(new ClassPathResource("view/before-test-schema.sql"));
-        populator.execute(dataSource);
-    }
 
     /**
      * 필터링 결과를 구분하기 위해, 필터링 대상 MBTI를 가지고 있는 유저 객체 2개를 생성한다.

--- a/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryTestSupport.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryTestSupport.java
@@ -1,0 +1,43 @@
+package com.example.spinlog.statistics.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class MBTIStatisticsRepositoryTestSupport {
+
+    @Component
+    @RequiredArgsConstructor
+    public static class ComponentToCreateUserMBTIView {
+        private final DataSource dataSource;
+
+        /**
+         * JPA에서 등록된 엔티티를 테이블로 생성 해주지만, 뷰는 생성 안되서, sql 파일로 직접 생성
+         * */
+        @EventListener(ApplicationReadyEvent.class)
+        @Order(1)
+        public void createUserMBTIView() {
+            ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+            populator.addScript(new ClassPathResource("view/before-test-schema.sql"));
+            populator.execute(dataSource);
+        }
+    }
+}

--- a/src/test/java/com/example/spinlog/statistics/repository/SpecificUserStatisticsRepositoryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/SpecificUserStatisticsRepositoryTest.java
@@ -26,11 +26,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class SpecificUserStatisticsRepositoryTest {
+public class SpecificUserStatisticsRepositoryTest extends MBTIStatisticsRepositoryTestSupport {
     @Autowired
     MBTIStatisticsRepository mbtiStatisticsRepository;
     @Autowired
@@ -50,11 +46,7 @@ public class SpecificUserStatisticsRepositoryTest {
     static User user2;
 
     @BeforeAll
-    static void setUp(@Autowired DataSource dataSource, @Autowired UserRepository userRepository, @Autowired ArticleRepository articleRepository) {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScript(new ClassPathResource("view/before-test-schema.sql"));
-        populator.execute(dataSource);
-
+    static void setUp(@Autowired UserRepository userRepository, @Autowired ArticleRepository articleRepository) {
         user1 = User.builder()
                 .email("survived@email")
                 .authenticationName("survivedUser")


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요? 🔍

users_mbti_view 중복 생성 코드 제거

## 어떻게 해결했나요? ✏️

@SpringBootTest 시
스프링이 내부적으로 설정이 같은 클래스들을 같은 환경에서 실행한다.

이때 같이 실행되면 몇몇 클래스에서 
각각이 @BeforeAll을 통해 뷰를 생성하고 있었다.
결국 같은 환경에서 뷰에 대한 생성 시도를 여러 번하기 때문에 
에러가 발생했다.

이를 해결하기 위해
뷰에 대한 생성 시도 코드를 전부 제거하고,
이 코드를 ApplicationReadyEvent를 수행하는 별도의 테스트용 컴포넌트를 생성해,
뷰 중복 생성을 막고 딱 한번만 생성되도록 설정했다.