### PR TITLE
hotfix: reduce test class name length

### DIFF
--- a/src/test/java/com/example/spinlog/statistics/repository/GenderStatisticsRepositoryQueryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/GenderStatisticsRepositoryQueryTest.java
@@ -148,7 +148,7 @@ class GenderStatisticsRepositoryQueryTest {
     }
 
     @Nested
-    class getAmountSumsAndCountsEachGenderAndEmotionBetweenStartDateAndEndDate_성별_감정별_금액_합과_개수를_반환하는_메서드 {
+    class getAmountSumsAndCountsEachGenderAndEmotionBetweenStartDateAndEndDate {
         @Test
         void 성별로_그룹핑한다() throws Exception {
             // when
@@ -227,7 +227,7 @@ class GenderStatisticsRepositoryQueryTest {
     }
 
     @Nested
-    class getAmountSumsEachGenderAndDayBetweenStartDateAndEndDate_성별_일별_금액_합을_반환하는_메서드 {
+    class getAmountSumsEachGenderAndDayBetweenStartDateAndEndDate {
         @Test
         void 성별로_그룹핑한다() throws Exception {
             // when
@@ -282,7 +282,7 @@ class GenderStatisticsRepositoryQueryTest {
     }
 
     @Nested
-    class getSatisfactionSumsAndCountsEachGenderBetweenStartDateAndEndDate_성별_만족도_합과_개수를_반환하는_메서드 {
+    class getSatisfactionSumsAndCountsEachGenderBetweenStartDateAndEndDate {
         @Test
         void 성별로_그룹핑한다() throws Exception {
             // when

--- a/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryQueryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/MBTIStatisticsRepositoryQueryTest.java
@@ -152,7 +152,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getAmountSumsAndCountsEachMBTIAndEmotionBetweenStartDateAndEndDate_MBTI_별_감정별_금액_합과_개수를_반환하는_메서드 {
+    class getAmountSumsAndCountsEachMBTIAndEmotionBetweenStartDateAndEndDate {
         @Test
         void MBTI_별로_그룹핑한다() throws Exception {
             // when
@@ -212,7 +212,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getAmountSumsEachMBTIAndDayBetweenStartDateAndEndDate_MBTI_별_일별_금액_합을_반환하는_메서드 {
+    class getAmountSumsEachMBTIAndDayBetweenStartDateAndEndDate {
         @Test
         void MBTI_별로_그룹핑한다() throws Exception {
             // when
@@ -264,7 +264,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getSatisfactionSumsAndCountsEachMBTIBetweenStartDateAndEndDate_MBTI_별_만족도_합과_개수를_반환하는_메서드 {
+    class getSatisfactionSumsAndCountsEachMBTIBetweenStartDateAndEndDate {
         @Test
         void MBTI_별로_그룹핑한다() throws Exception {
             // when
@@ -301,7 +301,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getAmountSumsAndCountsEachEmotionByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_감정별_금액_합과_개수를_반환하는_메서드 {
+    class getAmountSumsAndCountsEachEmotionByUserIdBetweenStartDateAndEndDate {
         @Test
         void 감정별로_그룹핑한다() throws Exception {
             // when
@@ -346,7 +346,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getAmountSumsEachDayByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_일별_금액_합을_반환하는_메서드 {@Test
+    class getAmountSumsEachDayByUserIdBetweenStartDateAndEndDate {@Test
         void 일별로_그룹핑한다() throws Exception {
             // when
             List<DailyAmountSumDto> dtos =
@@ -384,7 +384,7 @@ public class MBTIStatisticsRepositoryQueryTest extends MBTIStatisticsRepositoryT
     }
 
     @Nested
-    class getSatisfactionSumsAndCountsByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_만족도_합과_개수를_반환하는_메서드 {
+    class getSatisfactionSumsAndCountsByUserIdBetweenStartDateAndEndDate {
         @Test
         void 필터링_이후_각_satisfaction_의_합과_개수를_반환한다() throws Exception {
             // when

--- a/src/test/java/com/example/spinlog/statistics/repository/SpecificUserStatisticsRepositoryTest.java
+++ b/src/test/java/com/example/spinlog/statistics/repository/SpecificUserStatisticsRepositoryTest.java
@@ -149,7 +149,7 @@ public class SpecificUserStatisticsRepositoryTest extends MBTIStatisticsReposito
     }
 
     @Nested
-    class getAmountSumsAndCountsEachEmotionByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_감정별_금액_합과_개수를_반환하는_메서드 {
+    class getAmountSumsAndCountsEachEmotionByUserIdBetweenStartDateAndEndDate {
         @Test
         void 특정_유저의_정보만_가져온다() throws Exception {
             // when
@@ -189,7 +189,7 @@ public class SpecificUserStatisticsRepositoryTest extends MBTIStatisticsReposito
     }
 
     @Nested
-    class getAmountSumsEachDayByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_일별_금액_합을_반환하는_메서드 {
+    class getAmountSumsEachDayByUserIdBetweenStartDateAndEndDate {
         @Test
         void 특정_유저의_정보만_가져온다() throws Exception {
             // when
@@ -229,7 +229,7 @@ public class SpecificUserStatisticsRepositoryTest extends MBTIStatisticsReposito
     }
 
     @Nested
-    class getSatisfactionSumsAndCountsByUserIdBetweenStartDateAndEndDate_특정_유저에_대한_만족도_합과_개수를_반환하는_메서드 {
+    class getSatisfactionSumsAndCountsByUserIdBetweenStartDateAndEndDate {
         @Test
         void 특정_유저의_정보만_가져온다() throws Exception {
             // when


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요? 🔍

gradle 테스트 시
결과를 기록할 때 발생하는 에러를 해결한다.

## 어떻게 해결했나요? ✏️

현재 테스트 클래스의 이름이 너무 길어 문제가 발생한 것으로 확인된다.
그래서 테스트 클래스의 이름의 길이를 줄여서 문제를 해결했다.
